### PR TITLE
refactor: fix and simplify image workflow waiting logic

### DIFF
--- a/services/api_services.py
+++ b/services/api_services.py
@@ -74,3 +74,15 @@ def upscale_img(id, attempt=1, max_attempts=4):
             raise Exception(f'Failed to upscale image after {max_attempts} attempts.')
         
     return response.json()["url"]
+
+
+def get_progress(msgid):
+    url = f'https://api.thenextleg.io/v2/message/{msgid}?expireMins=2'
+
+    headers = {
+    'Authorization': f'Bearer {MIDJ_API_KEY}',
+    }
+
+    response = requests.request("GET", url, headers=headers)
+
+    return(response.text)

--- a/worlds/views.py
+++ b/worlds/views.py
@@ -288,7 +288,6 @@ def webhook(request):
     data = json.loads(request.body)
     print(f"Received data: {data}")
     ref = data.get("ref")
-    temp = data.get("buttonMessageId")
 
     if ref:
       print(f"Processing ref: {ref}")
@@ -296,11 +295,14 @@ def webhook(request):
         Model = apps.get_model("species", "species")
       else:
         Model = apps.get_model(ref["model"] + "s", ref["model"])
+
       instance = Model.objects.get(pk=ref["id"])
+      image_urls = data.get("imageUrls")
+      
       if ref.get("type"):
-        instance.img[ref["type"]] = temp
+        instance.img[ref["type"]] = image_urls[0]
       else:
-        instance.img = temp
+        instance.img = image_urls[0]
 
       instance.save()
     else: 


### PR DESCRIPTION
Adds a function to track image status using initial response, update database immediately with image url, fix wait logic to refer to status updates rather than db.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] All tests passing
- [x] Server runs locally
- [x] Endpoints look correct locally
- [x] Admin dashboard works locally
- [x] No remaining known bugs
